### PR TITLE
fix: sidebar.yml overriden #3

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -18,7 +18,7 @@ tst_flags = notest
 
 ### Docs ###
 branch = main
-custom_sidebar = False
+custom_sidebar = True
 doc_host = https://%(user)s.github.io
 doc_baseurl = /%(repo)s
 git_url = https://github.com/%(user)s/%(repo)s


### PR DESCRIPTION
### Description

Issue - `sidebar.yml` was being regenerated on every `nbdev_preview` execution.

> This was resulting in custom changes made being overriden.
Here's an example:-

If I change the section `implementation` to Pascal case `Implementation`,
upon running `nbdev_preview` it'd automatically set it to the directory name, 
which is `implementation`. This is not an expected behaviour.
> 

Solution

- set `custom_sidebar` in settings.ini to `True` .