### PR TITLE
fix: static port for `nbdev_preview` issue - #7

### DIFF
--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -1,6 +1,7 @@
 project:
   type: website
-
+  preview:
+    port: 3000
 format:
   html:
     theme: cosmo


### PR DESCRIPTION
### Description

Issue - A random port was used for preview
Solution - Setting port to 3000 in `nbs/_quarto.yml`